### PR TITLE
Fixed so that "last" and "n" come from correct OperationParameters values

### DIFF
--- a/src/Docker.Registry.DotNet/Endpoints/CatalogOperations.cs
+++ b/src/Docker.Registry.DotNet/Endpoints/CatalogOperations.cs
@@ -24,7 +24,7 @@ namespace Docker.Registry.DotNet.Endpoints
 
             var queryParameters = new QueryString();
 
-            queryParameters.AddIfNotNull("n", parameters.Last);
+            queryParameters.AddIfNotNull("n", parameters.Number);
             queryParameters.AddIfNotNull("last", parameters.Last);
 
             var response = await _client.MakeRequestAsync(cancellationToken, HttpMethod.Get, "v2/_catalog", queryParameters).ConfigureAwait(false);


### PR DESCRIPTION
So I found that the `last` and `n` query parameters were both coming from `Last` in `OperationParameters`. I've fixed the code.