### PR TITLE
Add authentication provider for Basic authentication

### DIFF
--- a/src/Docker.Registry.DotNet/Authentication/AnonymousOAuthAuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Authentication/AnonymousOAuthAuthenticationProvider.cs
@@ -10,12 +10,12 @@ namespace Docker.Registry.DotNet.Authentication
     {
         private readonly OAuthClient _client = new OAuthClient();
 
-        internal override Task AuthenticateAsync(HttpRequestMessage request)
+        public override Task AuthenticateAsync(HttpRequestMessage request)
         {
             return Task.CompletedTask;
         }
 
-        internal override async Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response)
+        public override async Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response)
         {
             foreach (var header in response.Headers.WwwAuthenticate)
             {

--- a/src/Docker.Registry.DotNet/Authentication/AuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Authentication/AuthenticationProvider.cs
@@ -13,7 +13,7 @@ namespace Docker.Registry.DotNet.Authentication
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        protected abstract Task AuthenticateAsync(HttpRequestMessage request);
+        public abstract Task AuthenticateAsync(HttpRequestMessage request);
 
         /// <summary>
         /// Called when the send is challenged.
@@ -21,6 +21,6 @@ namespace Docker.Registry.DotNet.Authentication
         /// <param name="request"></param>
         /// <param name="response"></param>
         /// <returns></returns>
-        protected abstract Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response);
+        public abstract Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response);
     }
 }

--- a/src/Docker.Registry.DotNet/Authentication/BasicAuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Authentication/BasicAuthenticationProvider.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Docker.Registry.DotNet.Authentication
+{
+    public class BasicAuthenticationProvider : AuthenticationProvider
+    {
+        private readonly string _username;
+        private readonly string _password;
+
+        public BasicAuthenticationProvider(string username, string password)
+        {
+            _username = username;
+            _password = password;
+        }
+
+        public override Task AuthenticateAsync(HttpRequestMessage request)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response)
+        {
+            foreach (var header in response.Headers.WwwAuthenticate)
+            {
+                if (header.Scheme == "Basic")
+                {
+                    // Convert password to base64 encoded string
+                    var passBytes = Encoding.UTF8.GetBytes($"{_username}:{_password}");
+                    var base64Pass = Convert.ToBase64String(passBytes);
+
+                    //Set the header
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Basic", base64Pass);
+
+                    return Task.CompletedTask;
+                }
+            }
+
+            throw new InvalidOperationException("No WWW-Authenticate challenge was found.");
+        }
+    }
+}

--- a/src/Docker.Registry.DotNet/Authentication/PasswordOAuthAuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Authentication/PasswordOAuthAuthenticationProvider.cs
@@ -18,12 +18,12 @@ namespace Docker.Registry.DotNet.Authentication
             _password = password;
         }
 
-        internal override Task AuthenticateAsync(HttpRequestMessage request)
+        public override Task AuthenticateAsync(HttpRequestMessage request)
         {
             return Task.CompletedTask;
         }
 
-        internal override async Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response)
+        public override async Task AuthenticateAsync(HttpRequestMessage request, HttpResponseMessage response)
         {
             foreach (var header in response.Headers.WwwAuthenticate)
             {


### PR DESCRIPTION
I've added an authentication provider for Basic authentication.
I also changed the abstract methods in AuthenticationProvider to public, so that users can implement their own providers if they want to.

I can split those changes in two pull requests if that's preferred.