### PR TITLE
Prevent conflicts with custom JSON serializer settings

### DIFF
--- a/src/Docker.Registry.DotNet/Helpers/JsonSerializer.cs
+++ b/src/Docker.Registry.DotNet/Helpers/JsonSerializer.cs
@@ -8,36 +8,27 @@ namespace Docker.Registry.DotNet.Helpers
     /// </summary>
     internal class JsonSerializer
     {
-        static JsonSerializer()
+        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
         {
-            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-                                                {
-                                                    NullValueHandling = NullValueHandling.Ignore
-                                                };
-        }
-
-        public JsonSerializer()
-        {
-            this.Converters = new JsonConverter[]
-                              {
-                                  //new JsonIso8601AndUnixEpochDateConverter(),
-                                  //new JsonVersionConverter(),
-                                  new StringEnumConverter()
-                                  //new TimeSpanSecondsConverter(),
-                                  //new TimeSpanNanosecondsConverter()
-                              };
-        }
-
-        private JsonConverter[] Converters { get; }
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters =
+            {
+                //new JsonIso8601AndUnixEpochDateConverter(),
+                //new JsonVersionConverter(),
+                new StringEnumConverter()
+                //new TimeSpanSecondsConverter(),
+                //new TimeSpanNanosecondsConverter()
+            }
+        };
 
         public T DeserializeObject<T>(string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, this.Converters);
+            return JsonConvert.DeserializeObject<T>(json, Settings);
         }
 
         public string SerializeObject<T>(T value)
         {
-            return JsonConvert.SerializeObject(value, this.Converters);
+            return JsonConvert.SerializeObject(value, Settings);
         }
     }
 }


### PR DESCRIPTION
Libraries should not override static `JsonConvert.DefaultSettings` delegate because it disables all custom JSON serializer settings that may be set in the user's project by this delegate. 