### PR TITLE
include the repository(plugin) scope in the authentication token

### DIFF
--- a/samples/Docker.Registry.Cli/Docker.Registry.Cli.csproj
+++ b/samples/Docker.Registry.Cli/Docker.Registry.Cli.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Docker.Registry.DotNet\Docker.Registry.DotNet.csproj" />
+    <ProjectReference Include="..\..\src\Docker.Registry.DotNet\Docker.Registry.DotNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Docker.Registry.Cli/Program.cs
+++ b/samples/Docker.Registry.Cli/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Docker.Registry.DotNet;
 using Docker.Registry.DotNet.Authentication;
 using Docker.Registry.DotNet.Models;
+using Docker.Registry.DotNet.Registry;
 
 namespace Docker.Registry.Cli
 {
@@ -35,7 +36,7 @@ namespace Docker.Registry.Cli
             //string url = "https://registry-1.docker.io/";
             string url = "http://10.0.4.44:5000/";
 
-            var configuration = new RegistryClientConfiguration(new Uri(url));
+            var configuration = new RegistryClientConfiguration(url);
 
             using (var client = configuration.CreateClient())
             {

--- a/src/Docker.Registry.DotNet/Authentication/PasswordOAuthAuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Authentication/PasswordOAuthAuthenticationProvider.cs
@@ -43,12 +43,14 @@ namespace Docker.Registry.DotNet.Authentication
             var token = await this._client.GetTokenAsync(
                             bearerBits.Realm,
                             bearerBits.Service,
-                            bearerBits.Scope,
+                            //Also include the repository(plugin) resource type to be able to access plugin repositories.
+                            //See https://docs.docker.com/registry/spec/auth/scope/
+                            bearerBits.Scope + " " + (bearerBits.Scope.Replace("repository:", "repository(plugin):")),
                             this._username,
                             this._password);
 
             //Set the header
-            request.Headers.Authorization = new AuthenticationHeaderValue(Schema, token.Token);
+            request.Headers.Authorization = new AuthenticationHeaderValue(Schema, token.AccessToken);
         }
     }
 }

--- a/src/Docker.Registry.DotNet/Endpoints/Implementations/ManifestOperations.cs
+++ b/src/Docker.Registry.DotNet/Endpoints/Implementations/ManifestOperations.cs
@@ -39,8 +39,17 @@ namespace Docker.Registry.DotNet.Endpoints.Implementations
 
             var response = await this._client.MakeRequestAsync(
                                cancellationToken,
-                               HttpMethod.Get,
+                               HttpMethod.Head,
                                $"v2/{name}/manifests/{reference}",
+                               null,
+                               headers).ConfigureAwait(false);
+
+            var digestReference = response.GetHeader("docker-content-digest");
+
+            response = await this._client.MakeRequestAsync(
+                               cancellationToken,
+                               HttpMethod.Get,
+                               $"v2/{name}/manifests/{digestReference}",
                                null,
                                headers).ConfigureAwait(false);
 

--- a/src/Docker.Registry.DotNet/Models/ListImageTagsParameters.cs
+++ b/src/Docker.Registry.DotNet/Models/ListImageTagsParameters.cs
@@ -6,7 +6,7 @@ namespace Docker.Registry.DotNet.Models
     {
         /// <summary>
         ///     Limit the number of entries in each response. It not present, all entries will be returned
-        /// </summary
+        /// </summary>
         [QueryParameter("n")]
         public int? Number { get; set; }
     }


### PR DESCRIPTION
include the repository(plugin) scope in the authentication token

this allows us to access the docker plugin repositories (e.g. https://hub.docker.com/r/grafana/loki-docker-driver)

please note that this can only be done when you provide a username and password

although this could also be done anonymously, the anonymous registry api does not support multiple scopes, so we would also, e.g., need to have a way to specify the scope in our library

this closes https://github.com/ChangemakerStudios/Docker.Registry.DotNet/issues/12