### PR TITLE
fix: GetHeader should ignore case and add RegistryApiException<TBody>

### DIFF
--- a/src/Docker.Registry.DotNet/Endpoints/Implementations/ManifestOperations.cs
+++ b/src/Docker.Registry.DotNet/Endpoints/Implementations/ManifestOperations.cs
@@ -45,7 +45,7 @@ namespace Docker.Registry.DotNet.Endpoints.Implementations
                                null,
                                headers).ConfigureAwait(false);
 
-            var digestReference = response.GetHeader("docker-content-digest");
+            var digestReference = response.GetHeader("Docker-Content-Digest");
 
             response = await this._client.MakeRequestAsync(
                                cancellationToken,

--- a/src/Docker.Registry.DotNet/Helpers/HttpUtility.cs
+++ b/src/Docker.Registry.DotNet/Helpers/HttpUtility.cs
@@ -44,7 +44,7 @@ namespace Docker.Registry.DotNet.Helpers
             if (response == null) throw new ArgumentNullException(nameof(response));
 
             return response.Headers
-                .FirstOrDefault(h => h.Key == name).Value?.FirstOrDefault();
+                .FirstOrDefault(h => h.Key.Equals(name, StringComparison.OrdinalIgnoreCase)).Value?.FirstOrDefault();
         }
 
         /// <summary>

--- a/src/Docker.Registry.DotNet/Registry/NetworkClient.cs
+++ b/src/Docker.Registry.DotNet/Registry/NetworkClient.cs
@@ -268,6 +268,17 @@ namespace Docker.Registry.DotNet.Registry
             return response;
         }
 
+        internal void HandleIfErrorResponse(RegistryApiResponse<string> response)
+        {
+            // If no customer handlers just default the response.
+            foreach (var handler in this._errorHandlers) handler(response);
+
+            // No custom handler was fired. Default the response for generic success/failures.
+            if (response.StatusCode < HttpStatusCode.OK
+                || response.StatusCode >= HttpStatusCode.BadRequest)
+                throw new RegistryApiException<string>(response);
+        }
+
         internal void HandleIfErrorResponse(RegistryApiResponse response)
         {
             // If no customer handlers just default the response.

--- a/src/Docker.Registry.DotNet/Registry/RegistryApiException.cs
+++ b/src/Docker.Registry.DotNet/Registry/RegistryApiException.cs
@@ -17,4 +17,15 @@ namespace Docker.Registry.DotNet.Registry
 
         public HttpResponseHeaders Headers { get; }
     }
+
+    public class RegistryApiException<TBody> : RegistryApiException
+    {
+        internal RegistryApiException(RegistryApiResponse<TBody> response)
+            : base(response)
+        {
+            this.Body = response.Body;
+        }
+
+        public TBody Body { get; }
+    }
 }


### PR DESCRIPTION
https://github.com/ChangemakerStudios/Docker.Registry.DotNet/blob/e9604591e360db7fcd5863f37d0205faed76460d/src/Docker.Registry.DotNet/Endpoints/Implementations/ManifestOperations.cs#L48

fix: `docker-content-digest` Get is null

add RegistryApiException<TBody>  to display detailed exceptions