### PR TITLE
Use HEAD request in GetDigest to resolve tag digests (fixes ECR)

### DIFF
--- a/src/Docker.Registry.DotNet/Application/Endpoints/ManifestOperations.cs
+++ b/src/Docker.Registry.DotNet/Application/Endpoints/ManifestOperations.cs
@@ -135,20 +135,34 @@ internal class ManifestOperations(RegistryClient client) : IManifestOperations
         ImageTag tag,
         CancellationToken token = default)
     {
-        var response = await this.MakeManifestRequest(name, tag.ToReference(), token);
+        // the registry spec only guarantees Docker-Content-Digest on a HEAD request --
+        // some registries (e.g. AWS ECR) omit it on GET (#34)
+        var response = await this.MakeManifestRequest(
+            name,
+            tag.ToReference(),
+            token,
+            HttpMethod.Head);
 
         var digestValue = response.GetHeader("Docker-Content-Digest");
 
-        return ImageDigest.TryCreate(digestValue, out var digest) ? digest : null;
+        if (ImageDigest.TryCreate(digestValue, out var digest)) return digest;
+
+        // fall back to GET for registries that don't return the header on HEAD
+        response = await this.MakeManifestRequest(name, tag.ToReference(), token);
+
+        digestValue = response.GetHeader("Docker-Content-Digest");
+
+        return ImageDigest.TryCreate(digestValue, out digest) ? digest : null;
     }
 
     private async Task<RegistryApiResponse<string>> MakeManifestRequest(
         string name,
         ImageReference reference,
-        CancellationToken token)
+        CancellationToken token,
+        HttpMethod? method = null)
     {
         return await client.MakeRequest(
-            HttpMethod.Get,
+            method ?? HttpMethod.Get,
             $"{client.RegistryVersion}/{name}/manifests/{reference}",
             null,
             _manifestHeaders,

--- a/test/Docker.Registry.DotNet.Tests/ManifestOperationsTests.cs
+++ b/test/Docker.Registry.DotNet.Tests/ManifestOperationsTests.cs
@@ -1,0 +1,111 @@
+// Copyright 2017-2024 Rich Quackenbush, Jaben Cargman
+//  and Docker.Registry.DotNet Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+using Docker.Registry.DotNet.Domain.ImageReferences;
+using Docker.Registry.DotNet.Domain.Registry;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Docker.Registry.DotNet.Tests;
+
+[TestFixture]
+public class ManifestOperationsTests
+{
+    private const string Digest =
+        "sha256:8c5d9e9a493cf7a1b6320761b4c916d037e0543ac9d85a7172055a1f691f1c32";
+
+    private const string ManifestBody =
+        """{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{},"layers":[]}""";
+
+    private static IRegistryClient CreateClient(FakeManifestHandler handler)
+    {
+        return new RegistryClientConfiguration("http://localhost:5000")
+            .SetHttpMessageHandler(handler)
+            .CreateClient();
+    }
+
+    [Test]
+    public async Task GetDigestUsesHeadRequest()
+    {
+        // e.g. AWS ECR only returns Docker-Content-Digest on HEAD (#34)
+        var handler = new FakeManifestHandler(digestOnHead: true, digestOnGet: false);
+
+        using var client = CreateClient(handler);
+
+        var digest = await client.Manifest.GetDigest("test", new ImageTag("latest"));
+
+        digest.Should().NotBeNull();
+        digest!.Value.Should().Be(Digest);
+        handler.Requests.Should().ContainSingle(m => m == HttpMethod.Head);
+    }
+
+    [Test]
+    public async Task GetDigestFallsBackToGetWhenHeadHasNoDigestHeader()
+    {
+        var handler = new FakeManifestHandler(digestOnHead: false, digestOnGet: true);
+
+        using var client = CreateClient(handler);
+
+        var digest = await client.Manifest.GetDigest("test", new ImageTag("latest"));
+
+        digest.Should().NotBeNull();
+        digest!.Value.Should().Be(Digest);
+        handler.Requests.Should().Equal(HttpMethod.Head, HttpMethod.Get);
+    }
+
+    [Test]
+    public async Task GetDigestReturnsNullWhenNoDigestHeaderIsReturned()
+    {
+        var handler = new FakeManifestHandler(digestOnHead: false, digestOnGet: false);
+
+        using var client = CreateClient(handler);
+
+        var digest = await client.Manifest.GetDigest("test", new ImageTag("latest"));
+
+        digest.Should().BeNull();
+    }
+
+    private class FakeManifestHandler(bool digestOnHead, bool digestOnGet) : HttpMessageHandler
+    {
+        public List<HttpMethod> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.Requests.Add(request.Method);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    request.Method == HttpMethod.Head ? string.Empty : ManifestBody,
+                    Encoding.UTF8,
+                    "application/vnd.docker.distribution.manifest.v2+json")
+            };
+
+            var includeDigest = request.Method == HttpMethod.Head ? digestOnHead : digestOnGet;
+
+            if (includeDigest) response.Headers.Add("Docker-Content-Digest", Digest);
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #34 — operations that map a tag to a digest fail against AWS ECR.

`GetDigest` read the `Docker-Content-Digest` header from a `GET` to the manifest endpoint, but the registry spec only guarantees that header on a `HEAD` request. ECR omits it on `GET`, so `GetDigest` returned `null`, which also broke tag-based `GetManifest` and `TagOperations` tag→digest mapping.

## Changes

- `GetDigest` now issues a `HEAD` request first (with the same `Accept` headers, since the returned digest depends on the negotiated media type).
- If the header is missing from the `HEAD` response, it falls back to the previous `GET` behavior so registries that only populate the header on `GET` cannot regress.
- Added `ManifestOperationsTests` covering all three paths with a fake `HttpMessageHandler` (no live registry needed): HEAD-only header (ECR scenario), GET-only header (fallback), and header absent on both (returns null).

## Verification

- All unit tests pass (15/15).
- Verified end-to-end against a local `registry:2`, including an ECR simulation via a delegating handler that strips `Docker-Content-Digest` from `GET` responses — `GetDigest` and tag-based `GetManifest` succeed in all scenarios and the digest matches what curl reports on `HEAD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest digest retrieval by checking the response headers first.
  * Added a fallback request to ensure digests can still be retrieved when the initial response lacks valid digest information.

* **Tests**
  * Added coverage for successful retrieval, fallback behavior, and cases where no digest is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->