### PR TITLE
Support OCI image manifests and indexes (fixes provenance-enabled images)

### DIFF
--- a/src/Docker.Registry.DotNet/Application/Endpoints/ManifestOperations.cs
+++ b/src/Docker.Registry.DotNet/Application/Endpoints/ManifestOperations.cs
@@ -26,7 +26,8 @@ internal class ManifestOperations(RegistryClient client) : IManifestOperations
             {
                 "Accept",
                 $"{ManifestMediaTypes.ManifestSchema1}, {ManifestMediaTypes.ManifestSchema2}, {
-                    ManifestMediaTypes.ManifestList}, {ManifestMediaTypes.ManifestSchema1Signed}"
+                    ManifestMediaTypes.ManifestList}, {ManifestMediaTypes.ManifestSchema1Signed}, {
+                        ManifestMediaTypes.OciManifest}, {ManifestMediaTypes.OciIndex}"
             }
         };
 
@@ -60,17 +61,19 @@ internal class ManifestOperations(RegistryClient client) : IManifestOperations
                     DockerContentDigest = response.GetHeader("Docker-Content-Digest"),
                     Etag = response.GetHeader("Etag")
                 },
-            ManifestMediaTypes.ManifestSchema2 => new GetImageManifestResult(
-                contentType,
-                client.JsonSerializer.DeserializeObject<ImageManifest2_2>(response.Body),
-                response.Body)
-            {
-                DockerContentDigest = response.GetHeader("Docker-Content-Digest")
-            },
-            ManifestMediaTypes.ManifestList => new GetImageManifestResult(
-                contentType,
-                client.JsonSerializer.DeserializeObject<ManifestList>(response.Body),
-                response.Body),
+            ManifestMediaTypes.ManifestSchema2 or ManifestMediaTypes.OciManifest => new
+                GetImageManifestResult(
+                    contentType,
+                    client.JsonSerializer.DeserializeObject<ImageManifest2_2>(response.Body),
+                    response.Body)
+                {
+                    DockerContentDigest = response.GetHeader("Docker-Content-Digest")
+                },
+            ManifestMediaTypes.ManifestList or ManifestMediaTypes.OciIndex => new
+                GetImageManifestResult(
+                    contentType,
+                    client.JsonSerializer.DeserializeObject<ManifestList>(response.Body),
+                    response.Body),
             _ => throw new UnknownManifestContentTypeException(
                 $"Unexpected ContentType '{contentType}'.")
         };
@@ -82,11 +85,16 @@ internal class ManifestOperations(RegistryClient client) : IManifestOperations
         ImageManifest manifest,
         CancellationToken token)
     {
+        // prefer the manifest's own media type (e.g. OCI) over the docker defaults
         var manifestMediaType = manifest switch
         {
             ImageManifest2_1 => ManifestMediaTypes.ManifestSchema1,
-            ImageManifest2_2 => ManifestMediaTypes.ManifestSchema2,
-            ManifestList => ManifestMediaTypes.ManifestList,
+            ImageManifest2_2 m => string.IsNullOrEmpty(m.MediaType)
+                ? ManifestMediaTypes.ManifestSchema2
+                : m.MediaType,
+            ManifestList m => string.IsNullOrEmpty(m.MediaType)
+                ? ManifestMediaTypes.ManifestList
+                : m.MediaType,
             _ => null
         };
 

--- a/src/Docker.Registry.DotNet/Domain/Manifests/ManifestMediaTypes.cs
+++ b/src/Docker.Registry.DotNet/Domain/Manifests/ManifestMediaTypes.cs
@@ -43,6 +43,22 @@ public static class ManifestMediaTypes
         "application/vnd.docker.distribution.manifest.list.v2+json";
 
     /// <summary>
+    ///     OCI image manifest (structurally equivalent to schema2). Used by buildkit,
+    ///     e.g. when building with provenance/SBOM attestations enabled.
+    /// </summary>
+    public const string OciManifest = "application/vnd.oci.image.manifest.v1+json";
+
+    /// <summary>
+    ///     OCI image index (structurally equivalent to the manifest list).
+    /// </summary>
+    public const string OciIndex = "application/vnd.oci.image.index.v1+json";
+
+    /// <summary>
+    ///     OCI container config JSON
+    /// </summary>
+    public const string OciContainerConfig = "application/vnd.oci.image.config.v1+json";
+
+    /// <summary>
     ///     Container config JSON
     /// </summary>
     public const string ContainerConfig = "application/vnd.docker.container.image.v1+json";

--- a/test/Docker.Registry.DotNet.Tests/OciManifestTests.cs
+++ b/test/Docker.Registry.DotNet.Tests/OciManifestTests.cs
@@ -1,0 +1,138 @@
+// Copyright 2017-2024 Rich Quackenbush, Jaben Cargman
+//  and Docker.Registry.DotNet Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+using Docker.Registry.DotNet.Domain.ImageReferences;
+using Docker.Registry.DotNet.Domain.Manifests;
+using Docker.Registry.DotNet.Domain.Registry;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Docker.Registry.DotNet.Tests;
+
+[TestFixture]
+public class OciManifestTests
+{
+    private const string IndexDigest =
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private const string ChildDigest =
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    private const string OciIndexBody =
+        $$"""
+          {"schemaVersion":2,"mediaType":"{{ManifestMediaTypes.OciIndex}}","manifests":[{"mediaType":"{{ManifestMediaTypes.OciManifest}}","digest":"{{ChildDigest}}","size":1234}]}
+          """;
+
+    private const string OciManifestBody =
+        $$"""
+          {"schemaVersion":2,"mediaType":"{{ManifestMediaTypes.OciManifest}}","config":{"mediaType":"{{ManifestMediaTypes.OciContainerConfig}}","digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","size":100},"layers":[]}
+          """;
+
+    private static IRegistryClient CreateClient(FakeOciRegistryHandler handler)
+    {
+        return new RegistryClientConfiguration("http://localhost:5000")
+            .SetHttpMessageHandler(handler)
+            .CreateClient();
+    }
+
+    [Test]
+    public async Task AcceptHeaderIncludesOciMediaTypes()
+    {
+        var handler = new FakeOciRegistryHandler();
+
+        using var client = CreateClient(handler);
+
+        await client.Manifest.GetManifest("test", ImageReference.Create(IndexDigest));
+
+        handler.LastAcceptHeader.Should().Contain(ManifestMediaTypes.OciIndex);
+        handler.LastAcceptHeader.Should().Contain(ManifestMediaTypes.OciManifest);
+    }
+
+    [Test]
+    public async Task GetManifestParsesOciIndexAsManifestList()
+    {
+        using var client = CreateClient(new FakeOciRegistryHandler());
+
+        var result = await client.Manifest.GetManifest("test", ImageReference.Create(IndexDigest));
+
+        result.MediaType.Should().Be(ManifestMediaTypes.OciIndex);
+        result.Manifest.Should().BeOfType<ManifestList>();
+
+        var list = (ManifestList)result.Manifest;
+        list.Manifests.Should().ContainSingle(m => m.Digest == ChildDigest);
+    }
+
+    [Test]
+    public async Task GetManifestParsesOciImageManifest()
+    {
+        using var client = CreateClient(new FakeOciRegistryHandler());
+
+        var result = await client.Manifest.GetManifest("test", ImageReference.Create(ChildDigest));
+
+        result.MediaType.Should().Be(ManifestMediaTypes.OciManifest);
+        result.Manifest.Should().BeOfType<ImageManifest2_2>();
+
+        var manifest = (ImageManifest2_2)result.Manifest;
+        manifest.Config?.MediaType.Should().Be(ManifestMediaTypes.OciContainerConfig);
+    }
+
+    [Test]
+    public async Task GetManifestByTagResolvesOciIndex()
+    {
+        using var client = CreateClient(new FakeOciRegistryHandler());
+
+        var result = await client.Manifest.GetManifest("test", ImageReference.Create("latest"));
+
+        result.Manifest.Should().BeOfType<ManifestList>();
+    }
+
+    /// <summary>
+    ///     Serves an OCI index at tag "latest"/its digest and an OCI image manifest at the
+    ///     child digest, mimicking an image pushed by buildkit with provenance enabled (#28).
+    /// </summary>
+    private class FakeOciRegistryHandler : HttpMessageHandler
+    {
+        public string? LastAcceptHeader { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.LastAcceptHeader = request.Headers.Accept.ToString();
+
+            var isChild = request.RequestUri!.AbsolutePath.EndsWith($"/manifests/{ChildDigest}");
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    isChild ? OciManifestBody : OciIndexBody,
+                    Encoding.UTF8,
+                    isChild ? ManifestMediaTypes.OciManifest : ManifestMediaTypes.OciIndex)
+            };
+
+            response.Headers.Add(
+                "Docker-Content-Digest",
+                isChild ? ChildDigest : IndexDigest);
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #28 — manifests of images pushed by buildkit with provenance enabled (`--provenance true`, the default in recent Docker versions) could not be read.

Such images use OCI media types: the top-level manifest is `application/vnd.oci.image.index.v1+json` with `application/vnd.oci.image.manifest.v1+json` children. The manifest `Accept` header only advertised the legacy Docker media types, so registries returned `404 Not Found`, and `GetManifest`'s content-type handling did not recognize OCI types.

## Changes

- Added `OciManifest`, `OciIndex`, and `OciContainerConfig` constants to `ManifestMediaTypes` and advertised the index/manifest types in the `Accept` header.
- `GetManifest` maps OCI types onto the existing models — the OCI image manifest is structurally identical to Docker schema2 (`ImageManifest2_2`) and the OCI index to `ManifestList` — so existing consumer code works unchanged.
- `PutManifest` now preserves a manifest's own `mediaType` when set, so a fetched OCI manifest re-pushed is no longer relabeled as Docker schema2.
- Added `OciManifestTests`: a fake `HttpMessageHandler` simulating a provenance-enabled registry, covering the Accept header, OCI index parsing, OCI image manifest parsing, and tag resolution.

## Verification

- **Control (unfixed `master`):** `GetManifest` against `ghcr.io/toras9000/test-provenance-true` (the reproduction repo from the issue) throws `RegistryApiException: NotFound`; `test-provenance-false` works — exactly as reported.
- **With this fix:** both succeed live against ghcr.io. The provenance-true image returns the OCI index as `ManifestList`, and fetching a child digest returns the OCI image manifest as `ImageManifest2_2`.
- All unit tests pass (16/16).

## Note

Touches `ManifestOperations.cs` near the region changed by #35 (issue #34's HEAD-request fix) — whichever merges second may need a trivial conflict resolution.