### PR TITLE
Fall back to basic-auth GET when the OAuth2 token grant is unsupported

### DIFF
--- a/src/Docker.Registry.DotNet/Application/Authentication/AnonymousOAuthAuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Application/Authentication/AnonymousOAuthAuthenticationProvider.cs
@@ -49,12 +49,14 @@ public class AnonymousOAuthAuthenticationProvider : AuthenticationProvider
             bearerBits.Service,
             bearerBits.Scope);
 
-        if (token?.Token == null)
+        var accessToken = token?.Token ?? token?.AccessToken;
+
+        if (accessToken == null)
         {
-            throw new ArgumentNullException(nameof(token.Token), "Authorization token cannot be null");
+            throw new ArgumentNullException(nameof(accessToken), "Authorization token cannot be null");
         }
 
         //Set the header
-        request.Headers.Authorization = new AuthenticationHeaderValue(Schema, token.Token);
+        request.Headers.Authorization = new AuthenticationHeaderValue(Schema, accessToken);
     }
 }

--- a/src/Docker.Registry.DotNet/Application/Authentication/PasswordOAuthAuthenticationProvider.cs
+++ b/src/Docker.Registry.DotNet/Application/Authentication/PasswordOAuthAuthenticationProvider.cs
@@ -60,13 +60,16 @@ public class PasswordOAuthAuthenticationProvider(string username, string passwor
             username,
             password);
         
-        if (token?.AccessToken == null)
+        //The OAuth2 grant returns access_token; the classic token endpoint returns token.
+        var accessToken = token?.AccessToken ?? token?.Token;
+
+        if (accessToken == null)
         {
-            throw new ArgumentNullException(nameof(token.AccessToken), "Authorization token cannot be null");
+            throw new ArgumentNullException(nameof(accessToken), "Authorization token cannot be null");
         }
 
         //Set the header
         request.Headers.Authorization =
-            new AuthenticationHeaderValue(Schema, token.AccessToken);
+            new AuthenticationHeaderValue(Schema, accessToken);
     }
 }

--- a/src/Docker.Registry.DotNet/Application/OAuth/OAuthClient.cs
+++ b/src/Docker.Registry.DotNet/Application/OAuth/OAuthClient.cs
@@ -17,9 +17,11 @@ using Docker.Registry.DotNet.Application.QueryStrings;
 
 namespace Docker.Registry.DotNet.Application.OAuth;
 
-internal class OAuthClient
+internal class OAuthClient(HttpClient? client = null)
 {
-    private static readonly HttpClient _client = new();
+    private static readonly HttpClient _defaultClient = new();
+
+    private readonly HttpClient _client = client ?? _defaultClient;
 
     private async Task<OAuthToken?> GetTokenInner(
         string? realm,
@@ -31,45 +33,40 @@ internal class OAuthClient
     {
         using var activity = Assembly.Source.StartActivity("OAuthClient.GetTokenInner()");
 
-        HttpRequestMessage request;
-
-        if (username == null || password == null)
-        {
-            var queryString = new QueryString();
-
-            queryString.AddIfNotEmpty("service", service);
-            queryString.AddIfNotEmpty("scope", scope);
-
-            var builder = new UriBuilder(new Uri(realm))
-            {
-                Query = queryString.GetQueryString()
-            };
-
-            request = new HttpRequestMessage(HttpMethod.Get, builder.Uri);
-        }
-        else
-        {
-            request = new HttpRequestMessage(HttpMethod.Post, realm)
-            {
-                Content = new FormUrlEncodedContent(
-                    new Dictionary<string, string?>
-                    {
-                        { "client_id", "Docker.Registry.DotNet" },
-                        { "grant_type", "password" },
-                        { "username", username },
-                        { "password", password },
-                        { "service", service },
-                        { "scope", scope }
-                    }
-                )
-            };
-        }
-
         activity?.AddEvent(new ActivityEvent("Getting Token"));
 
         try
         {
-            using var response = await _client.SendAsync(request, token);
+            if (username != null && password != null)
+            {
+                // Try the OAuth2 password grant first -- it supports multiple scopes
+                // (e.g. the repository(plugin) scope on Docker Hub).
+                using var oauthResponse = await _client.SendAsync(
+                    BuildOAuth2Request(realm, service, scope, username, password),
+                    token);
+
+                if (oauthResponse.IsSuccessStatusCode)
+                    return await ReadToken(oauthResponse, token);
+
+                // Token servers that only implement the classic token endpoint
+                // (e.g. docker/distribution) reject the POST -- fall back to
+                // a GET with basic auth per the Docker Registry token spec.
+                if (oauthResponse.StatusCode is not (HttpStatusCode.MethodNotAllowed
+                    or HttpStatusCode.NotFound or HttpStatusCode.BadRequest))
+                {
+                    activity?.AddEvent(new ActivityEvent("Failed to Authenticate"));
+
+                    throw new UnauthorizedAccessException(
+                        $"Unable to authenticate: {await oauthResponse.Content.ReadAsStringAsyncWithCancellation(token)}");
+                }
+
+                activity?.AddEvent(
+                    new ActivityEvent("OAuth2 Grant Unsupported - Falling Back to Basic Auth"));
+            }
+
+            using var response = await _client.SendAsync(
+                BuildTokenRequest(realm, service, scope, username, password),
+                token);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -79,11 +76,11 @@ internal class OAuthClient
                     $"Unable to authenticate: {await response.Content.ReadAsStringAsyncWithCancellation(token)}");
             }
 
-            var body = await response.Content.ReadAsStringAsyncWithCancellation(token);
-
-            var authToken = JsonConvert.DeserializeObject<OAuthToken>(body);
-
-            return authToken;
+            return await ReadToken(response, token);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -91,6 +88,68 @@ internal class OAuthClient
 
             throw new UnauthorizedAccessException($"Unable to authenticate: {ex}");
         }
+    }
+
+    private static HttpRequestMessage BuildOAuth2Request(
+        string? realm,
+        string? service,
+        string? scope,
+        string username,
+        string password)
+    {
+        return new HttpRequestMessage(HttpMethod.Post, realm)
+        {
+            Content = new FormUrlEncodedContent(
+                new Dictionary<string, string?>
+                {
+                    { "client_id", "Docker.Registry.DotNet" },
+                    { "grant_type", "password" },
+                    { "username", username },
+                    { "password", password },
+                    { "service", service },
+                    { "scope", scope }
+                }
+            )
+        };
+    }
+
+    private static HttpRequestMessage BuildTokenRequest(
+        string? realm,
+        string? service,
+        string? scope,
+        string? username,
+        string? password)
+    {
+        var queryString = new QueryString();
+
+        queryString.AddIfNotEmpty("service", service);
+        queryString.AddIfNotEmpty("scope", scope);
+
+        var builder = new UriBuilder(new Uri(realm))
+        {
+            Query = queryString.GetQueryString()
+        };
+
+        var request = new HttpRequestMessage(HttpMethod.Get, builder.Uri);
+
+        if (username != null && password != null)
+        {
+            var credentials = Convert.ToBase64String(
+                Encoding.UTF8.GetBytes($"{username}:{password}"));
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        }
+
+        return request;
+    }
+
+    private static async Task<OAuthToken?> ReadToken(
+        HttpResponseMessage response,
+        CancellationToken token)
+    {
+        var body = await response.Content.ReadAsStringAsyncWithCancellation(token);
+
+        return JsonConvert.DeserializeObject<OAuthToken>(body);
     }
 
     public Task<OAuthToken?> GetToken(

--- a/test/Docker.Registry.DotNet.Tests/OAuth/OAuthClientTests.cs
+++ b/test/Docker.Registry.DotNet.Tests/OAuth/OAuthClientTests.cs
@@ -1,0 +1,143 @@
+// Copyright 2017-2024 Rich Quackenbush, Jaben Cargman
+//  and Docker.Registry.DotNet Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System.Net;
+using System.Text;
+
+using Docker.Registry.DotNet.Application.OAuth;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Docker.Registry.DotNet.Tests.OAuth;
+
+[TestFixture]
+public class OAuthClientTests
+{
+    private const string Realm = "https://auth.example.com/token";
+
+    private static readonly string ClassicTokenJson = """{"token":"classic-token"}""";
+
+    private static readonly string OAuth2TokenJson = """{"access_token":"oauth2-token"}""";
+
+    private static OAuthClient CreateClient(FakeHttpHandler handler) => new(new HttpClient(handler));
+
+    [Test]
+    public async Task GivenNoCredentials_WhenGettingAToken_ThenItShouldUseGetWithoutAuthorization()
+    {
+        var handler = new FakeHttpHandler(
+            _ => Respond(HttpStatusCode.OK, ClassicTokenJson));
+
+        var token = await CreateClient(handler).GetToken(Realm, "service", "scope");
+
+        token?.Token.Should().Be("classic-token");
+
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].Method.Should().Be(HttpMethod.Get);
+        handler.Requests[0].Headers.Authorization.Should().BeNull();
+        handler.Requests[0].RequestUri!.Query.Should().Contain("service=service").And.Contain("scope=scope");
+    }
+
+    [Test]
+    public async Task GivenCredentials_WhenTheOAuth2GrantSucceeds_ThenItShouldNotFallBack()
+    {
+        var handler = new FakeHttpHandler(
+            _ => Respond(HttpStatusCode.OK, OAuth2TokenJson));
+
+        var token = await CreateClient(handler).GetToken(Realm, "service", "scope", "user", "pass");
+
+        token?.AccessToken.Should().Be("oauth2-token");
+
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].Method.Should().Be(HttpMethod.Post);
+    }
+
+    [TestCase(HttpStatusCode.MethodNotAllowed)]
+    [TestCase(HttpStatusCode.NotFound)]
+    [TestCase(HttpStatusCode.BadRequest)]
+    public async Task GivenCredentials_WhenTheOAuth2GrantIsUnsupported_ThenItShouldFallBackToBasicAuthGet(
+        HttpStatusCode oauth2Status)
+    {
+        var handler = new FakeHttpHandler(
+            request => request.Method == HttpMethod.Post
+                ? Respond(oauth2Status, "method not allowed")
+                : Respond(HttpStatusCode.OK, ClassicTokenJson));
+
+        var token = await CreateClient(handler).GetToken(Realm, "service", "scope", "user", "pass");
+
+        token?.Token.Should().Be("classic-token");
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[0].Method.Should().Be(HttpMethod.Post);
+        handler.Requests[1].Method.Should().Be(HttpMethod.Get);
+
+        var authorization = handler.Requests[1].Headers.Authorization;
+
+        authorization.Should().NotBeNull();
+        authorization!.Scheme.Should().Be("Basic");
+        authorization.Parameter.Should()
+            .Be(Convert.ToBase64String(Encoding.UTF8.GetBytes("user:pass")));
+    }
+
+    [Test]
+    public async Task GivenCredentials_WhenTheOAuth2GrantIsRejected_ThenItShouldThrowWithoutFallingBack()
+    {
+        var handler = new FakeHttpHandler(
+            _ => Respond(HttpStatusCode.Unauthorized, "invalid credentials"));
+
+        var getToken = () => CreateClient(handler).GetToken(Realm, "service", "scope", "user", "pass");
+
+        await getToken.Should().ThrowAsync<UnauthorizedAccessException>();
+
+        handler.Requests.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task GivenCredentials_WhenTheFallbackAlsoFails_ThenItShouldThrow()
+    {
+        var handler = new FakeHttpHandler(
+            request => request.Method == HttpMethod.Post
+                ? Respond(HttpStatusCode.MethodNotAllowed, "method not allowed")
+                : Respond(HttpStatusCode.Unauthorized, "invalid credentials"));
+
+        var getToken = () => CreateClient(handler).GetToken(Realm, "service", "scope", "user", "pass");
+
+        await getToken.Should().ThrowAsync<UnauthorizedAccessException>();
+
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    private static HttpResponseMessage Respond(HttpStatusCode statusCode, string body) =>
+        new(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+
+    private class FakeHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.Requests.Add(request);
+
+            return Task.FromResult(responder(request));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #27.

## Problem

#13 switched credentialed authentication in `OAuthClient` from the classic Docker Registry token flow (GET with `service`/`scope` query params + Basic auth header) to an OAuth2 password-grant POST. Token servers that only implement the classic token endpoint — including stock `docker/distribution` — reject that POST with **405 Method Not Allowed**, so username/password auth has been broken against those registries ever since.

A secondary bug: `PasswordOAuthAuthenticationProvider` required the `access_token` response field, but the classic endpoint returns `token` — so even a successful classic response would have been rejected.

## Fix

- `OAuthClient` still tries the OAuth2 password grant first (preserving #13's multi-scope behavior for Docker Hub). If the server answers **405 / 404 / 400** — the signatures of a server without the OAuth2 endpoint — it falls back to a GET with Basic auth per the [token spec](https://distribution.github.io/distribution/spec/auth/token/). A real credential rejection (401/403) on the POST still throws immediately without a fallback.
- Both authentication providers now accept `access_token ?? token` (and vice versa for anonymous).
- `OAuthClient` gained an optional `HttpClient` constructor parameter (internal, defaults to the shared static client) so the flow is unit-testable.

Note on 400: some servers reject an unsupported grant type with 400 rather than 405, so it triggers the fallback too. If credentials are simply wrong, the cost is one extra failing request before the throw.

## Tests

7 new tests in `OAuthClientTests` cover: anonymous GET, successful POST (no fallback), fallback on 405/404/400 with the correct Basic header, no fallback on 401, and both paths failing. Full suite: 26 passed.